### PR TITLE
Pyfixest fitter support 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@
 *.out
 *.synctex.gz
 *venv
+*newenv
 *build
 debug.py
 pyvenv.cfg

--- a/duckreg/estimators.py
+++ b/duckreg/estimators.py
@@ -4,6 +4,7 @@ import re
 from tqdm import tqdm
 from .demean import demean
 from .duckreg import DuckReg, wls
+from pyfixest.estimation.estimation import feols
 
 
 ################################################################################
@@ -16,11 +17,12 @@ class DuckRegression(DuckReg):
         table_name: str,
         formula: str,
         cluster_col: str,
+        seed: int,
         n_bootstraps: int = 100,
-        seed: int = 42,
         rowid_col: str = "rowid",
+        fitter: str = "numpy"
     ):
-        super().__init__(db_name, table_name, n_bootstraps, seed)
+        super().__init__(db_name, table_name, n_bootstraps, seed, fitter = fitter)
         self.formula = formula
         self.cluster_col = cluster_col
         self.rowid_col = rowid_col
@@ -91,6 +93,23 @@ class DuckRegression(DuckReg):
         y, X, n = self.collect_data(data=self.df_compressed)
 
         return wls(X, y, n)
+
+    def estimate_feols(self):
+
+        if self.fevars:
+            fml = f"mean_{self.outcome_vars[0]} ~ {' + '.join(self.covars)} | {' + '.join(self.fevars)}"
+        else:
+            fml = f"mean_{self.outcome_vars[0]} ~ {' + '.join(self.covars)}"
+
+        fit = feols(
+            fml = fml,
+            data = self.df_compressed,
+            vcov = "iid",  # most performant
+            weights = "count",
+            weights_type = "fweights"
+        )
+
+        return fit
 
     def bootstrap(self):
         if self.fevars:
@@ -163,10 +182,10 @@ class DuckMundlak(DuckReg):
         table_name: str,
         outcome_var: str,
         covariates: list,
+        seed: int,
         unit_col: str,
         time_col: str = None,
         n_bootstraps: int = 100,
-        seed: int = 42,
         cluster_col: str = None,
     ):
         super().__init__(db_name, table_name, n_bootstraps, seed)
@@ -259,6 +278,9 @@ class DuckMundlak(DuckReg):
         y, X, n = self.collect_data(data=self.df_compressed)
         return wls(X, y, n)
 
+    def estimate_feols(self):
+        pass
+
     def bootstrap(self):
         rhs = (
             self.covariates
@@ -339,8 +361,8 @@ class DuckDoubleDemeaning(DuckReg):
         treatment_var: str,
         unit_col: str,
         time_col: str,
+        seed: int,
         n_bootstraps: int = 100,
-        seed: int = 42,
         cluster_col: str = None,
     ):
         super().__init__(db_name, table_name, n_bootstraps, seed)
@@ -421,6 +443,9 @@ class DuckDoubleDemeaning(DuckReg):
     def estimate(self):
         y, X, n = self.collect_data(data=self.df_compressed)
         return wls(X, y, n)
+
+    def estimate_feols(self):
+        pass
 
     def bootstrap(self):
         boot_coefs = np.zeros((self.n_bootstraps, 2))  # Intercept and treatment effect

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pandas
 tqdm
 duckdb
 numba
+pyfixest


### PR DESCRIPTION
This PR does two things: 

1. It requires users to specify the seed by hand (vs the 42 default 😅). Highly opinionated by me, happy to take it out =) 
2. Adds support to run the OLS fit via `pyfixest` by adding a `fitter` method to the base duck regression class. 

